### PR TITLE
Dos erratas y una simplificación

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ lo almacenaremos con el `string`:
 '..3.2.6..9..3.5..1..18.64....81.29..7.......8..67.82....26.95..8..2.3..9..5.1.3..'
 ```
 
-Por otra parte implementaremos el diccionario de tal manera que las *keys* serán los *strings* correspondientes a las casillas (`'A1', 'A2', ..., 'I9'`) y los valores seran o bien el dígito en la casilla o '.'.
+Por otra parte implementaremos el diccionario de tal manera que las *keys* serán los *strings* correspondientes a las casillas (`'A1', 'A2', ..., 'I9'`) y los valores serán o bien el dígito en la casilla o '.'.
 
 Para generar nuestra estructura de datos que contendrá el tablero cuadriculado vamos a empezar programando una función de soporte que llamaremos `cross(a, b)` que dados dos strings `a` y `b` la función retorna la lista  (recordemos que una lista se especifica con `[` `]`) formada por todas las posibles concatenaciones de letras `s` en el string `a` con la `t` en el string `b`.  
 
@@ -100,7 +100,7 @@ boxes = cross(rows, cols)
 ```
 Podemos comprobarlo con `print boxes` o `print (boxes)` (dependiendo si usamos Python 2.x o 3.x) que nos dará la siguiente salida:
 ```python
-[['A1', 'A2', 'A3', 'A4', 'A5', 'A6', 'A7', 'A8', 'A9'], ['B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'B8', 'B9'], ['C1', 'C2', 'C3', 'C4', 'C5', 'C6', 'C7', 'C8', 'C9'], ['D1', 'D2', 'D3', 'D4', 'D5', 'D6', 'D7', 'D8', 'D9'], ['E1', 'E2', 'E3', 'E4', 'E5', 'E6', 'E7', 'E8', 'E9'], ['F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9'], ['G1', 'G2', 'G3', 'G4', 'G5', 'G6', 'G7', 'G8', 'G9'], ['H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'H7', 'H8', 'H9'], ['I1', 'I2', 'I3', 'I4', 'I5', 'I6', 'I7', 'I8', 'I9']]
+['A1', 'A2', 'A3', 'A4', 'A5', 'A6', 'A7', 'A8', 'A9', 'B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'B8', 'B9', 'C1', 'C2', 'C3', 'C4', 'C5', 'C6', 'C7', 'C8', 'C9', 'D1', 'D2', 'D3', 'D4', 'D5', 'D6', 'D7', 'D8', 'D9', 'E1', 'E2', 'E3', 'E4', 'E5', 'E6', 'E7', 'E8', 'E9', 'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'G1', 'G2', 'G3', 'G4', 'G5', 'G6', 'G7', 'G8', 'G9', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'H7', 'H8', 'H9', 'I1', 'I2', 'I3', 'I4', 'I5', 'I6', 'I7', 'I8', 'I9']
 
 ```
 
@@ -259,14 +259,14 @@ Juntamos todo en una sola lista:
 unitlist = row_units + column_units + square_units
 
 ```
-Con el constructor `dict()` que construye diccionarios directamente de secuencias de pares clave-valor vamos a generar el diccionario `units` que nos dice por cada casilla `s in boxes` que casillas componen la fila, la columna i el cuadrado de 3x3 cuyo valor debemos tener en cuenta: 
+Vamos a generar el diccionario `units` que nos dice por cada casilla `s in boxes` que casillas componen la fila, la columna i el cuadrado de 3x3 cuyo valor debemos tener en cuenta: 
 ```python
-units = dict((s, [u for u in unitlist if s in u]) for s in boxes)
+units = {s: [u for u in unitlist if s in u] for s in boxes}
  ```
 Por otro lado, usando el módulo `sets` (que permite construir y manipular colecciones no ordenadas de elementos únicos) construimos el diccionario `peers` que nos elimina duplicados de casillas por cada casilla:
 
 ```python
-peers = dict((s, set(sum(units[s],[]))-set([s])) for s in boxes)
+peers = {s: set(sum(units[s],[]))-set([s]) for s in boxes}
  ```
 
 En resumen, la función `eliminate()` iterará sobre todas las celdas de la cuadrícula que tienen solo un valor asignado, y borrará este valor de todos sus pares. La vamos a implementar de tal manera que reciba como entrada un diccionario y retornará otro diccionario con los valores eliminados.

--- a/Sudoku.ipynb
+++ b/Sudoku.ipynb
@@ -12,10 +12,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 1,
+   "metadata": {},
    "outputs": [],
    "source": [
     "rows = 'ABCDEFGHI'\n",
@@ -24,10 +22,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 2,
+   "metadata": {},
    "outputs": [],
    "source": [
     "def cross(A, B):\n",
@@ -37,10 +33,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 3,
+   "metadata": {},
    "outputs": [],
    "source": [
     "boxes = cross(rows, cols)\n",
@@ -51,10 +45,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 4,
+   "metadata": {},
    "outputs": [],
    "source": [
     "unitlist = row_units + column_units + square_units"
@@ -62,22 +54,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 5,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "units = dict((s, [u for u in unitlist if s in u]) for s in boxes)\n",
-    "peers = dict((s, set(sum(units[s],[]))-set([s])) for s in boxes)"
+    "units = {s: [u for u in unitlist if s in u] for s in boxes}\n",
+    "peers = {s: set(sum(units[s],[]))-set([s])  for s in boxes}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 6,
+   "metadata": {},
    "outputs": [],
    "source": [
     "def display(values):  \n",
@@ -92,10 +80,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 7,
+   "metadata": {},
    "outputs": [],
    "source": [
     "def grid_values_original(grid):\n",
@@ -104,10 +90,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 8,
+   "metadata": {},
    "outputs": [],
    "source": [
     "def grid_values(grid):\n",
@@ -122,10 +106,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 9,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -164,10 +146,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 10,
+   "metadata": {},
    "outputs": [],
    "source": [
     "def eliminate(values):\n",
@@ -184,10 +164,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 11,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -227,10 +205,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 12,
+   "metadata": {},
    "outputs": [],
    "source": [
     "def only_choice(values):\n",
@@ -244,10 +220,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 13,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -290,10 +264,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 14,
+   "metadata": {},
    "outputs": [],
    "source": [
     "def reduce_sudoku(values):\n",
@@ -320,10 +292,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 15,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -366,10 +336,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 16,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -408,10 +376,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 17,
+   "metadata": {},
    "outputs": [],
    "source": [
     "def search(values):\n",
@@ -436,10 +402,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 18,
+   "metadata": {},
    "outputs": [],
    "source": [
     "def solve(grid):\n",
@@ -450,10 +414,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 19,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -492,10 +454,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 20,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -546,7 +506,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -560,7 +520,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Leí su post esta semana como parte de un recurso adicional en mi clase de Inteligencia Artificial. Me pareción un ejemplo bonito y sencillo que transmite bien en qué consiste el traversar el espacio de soluciones. 

Mientras leía el guión, me percaté de 2 erratas y una expresión en Python que podría haber sido escrita de manera más simple.

---

https://github.com/jorditorresBCN/Sudoku/blob/d2594d554afa05f18f947377b1637e6cdef5a57c/README.md?plain=1#L102-L105
En el primer caso, esta no sería la verdadera salida de `print(boxes)`. En vez de una lista de listas de cadenas de texto, sería una lista de cadenas de texto, cada una representando un `box`.

> ```python
> ['A1', 'A2', 'A3', 'A4', 'A5', 'A6', 'A7', 'A8', 'A9', 'B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'B8', 'B9', 'C1', 'C2', 'C3', 'C4', 'C5', 'C6', 'C7', 'C8', 'C9', 'D1', 'D2', 'D3', 'D4', 'D5', 'D6', 'D7', 'D8', 'D9', 'E1', 'E2', 'E3', 'E4', 'E5', 'E6', 'E7', 'E8', 'E9', 'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'G1', 'G2', 'G3', 'G4', 'G5', 'G6', 'G7', 'G8', 'G9', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'H7', 'H8', 'H9', 'I1', 'I2', 'I3', 'I4', 'I5', 'I6', 'I7', 'I8', 'I9']
> 
> ```

---
https://github.com/jorditorresBCN/Sudoku/blob/d2594d554afa05f18f947377b1637e6cdef5a57c/README.md?plain=1#L262-L270
En el segundo caso, aunque el código en si no es incorrecto, hay una forma equivalente de hacer lo mismo en python, que en mi opinión subjetiva requirere de menos paréntesis lo cual la hace más legible y fácil de entender. Además, esta funcionalidad está presente tanto en Python 2.7 como Python 3, por lo que no pensé que fuera dejado a propósito por temas de compatibilidad

> Vamos a generar el diccionario `units` que nos dice por cada casilla `s in boxes` que casillas componen la fila, la columna i el cuadrado de 3x3 cuyo valor debemos tener en cuenta: 
> ```python
> units = {s: [u for u in unitlist if s in u] for s in boxes}
> ```
> Por otro lado, usando el módulo `sets` (que permite construir y manipular colecciones no ordenadas de elementos únicos) construimos el diccionario `peers` que nos elimina duplicados de casillas por cada casilla:
> 
> ```python
> peers = {s: set(sum(units[s],[]))-set([s]) for s in boxes}
> ```

---

Gracias por su tiempo